### PR TITLE
Expose `result_error` for simplify with locks variants as well

### DIFF
--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -103,6 +103,7 @@ pub fn simplify_with_locks(
     target_count: usize,
     target_error: f32,
     options: SimplifyOptions,
+    result_error: Option<&mut f32>,
 ) -> Vec<u32> {
     let vertex_data = vertices.reader.get_ref();
     let vertex_data = vertex_data.as_ptr().cast::<u8>();
@@ -124,7 +125,7 @@ pub fn simplify_with_locks(
             target_count,
             target_error,
             options.bits(),
-            std::ptr::null_mut(),
+            result_error.map_or_else(std::ptr::null_mut, |v| v as *mut _),
         )
     };
     result.resize(index_count, 0u32);
@@ -145,6 +146,7 @@ pub fn simplify_with_locks_decoder<T: DecodePosition>(
     target_count: usize,
     target_error: f32,
     options: SimplifyOptions,
+    result_error: Option<&mut f32>,
 ) -> Vec<u32> {
     let positions = vertices
         .iter()
@@ -167,7 +169,7 @@ pub fn simplify_with_locks_decoder<T: DecodePosition>(
             target_count,
             target_error,
             options.bits(),
-            std::ptr::null_mut(),
+            result_error.map_or_else(std::ptr::null_mut, |v| v as *mut _),
         )
     };
     result.resize(index_count, 0u32);


### PR DESCRIPTION
Needed to expose the result error for the simplify with lock variants. Good for completeness and unifying API as well.